### PR TITLE
Introduce the IZ80ProcessorInterruptEvents interface

### DIFF
--- a/Docs/Interrupts.md
+++ b/Docs/Interrupts.md
@@ -10,7 +10,7 @@ The `HALT` instruction behaves the expected way: after this instruction is execu
 
 ### Interrupt events
 
-[IZ80Processor](../Main/IZ80Processor.cs) provides the following interrupt related events:
+[IZ80ProcessorInterruptEvents](../Main/IZ80ProcessorInterruptEvents.cs) provides the following interrupt related events:
 
 * _`MaskableInterruptServicingStart`_ is fired right before a maskable interrupt is going to be serviced. The execution state is as follows when the event is fired:
 
@@ -25,3 +25,5 @@ The `HALT` instruction behaves the expected way: after this instruction is execu
 * _`BeforeRetiInstructionExecution`_ and _`BeforeRetnInstructionExecution`_ are fired before a RETI/RETN instruction is about to be executed, right after the corresponding _`BeforeInstructionExecution`_ event.
 
 * _`AfterRetiInstructionExecution`_ and _`AfterRetnInstructionExecution`_ are fired after a RETI/RETN instruction is about to be executed, right after the corresponding _`AfterInstructionExecution`_ event.
+
+ **Note:** the `IZ80ProcessorInterruptEvents` interface has the above events and nothing else. A separate interface was created to avoid breaking external code that depends on `IZ80Processor`; the `Z80Processor` class implements both interfaces.

--- a/Main/IZ80Processor.cs
+++ b/Main/IZ80Processor.cs
@@ -395,48 +395,6 @@ namespace Konamiman.Z80dotNet
         /// </summary>
         event EventHandler<AfterInstructionExecutionEventArgs> AfterInstructionExecution;
 
-        /// <summary>
-        /// Triggered when a maskable interrupt is about to be serviced.
-        /// 
-        /// For IM 0: The opcode has been already fetched from the data bus and is about to be executed.
-        /// 
-        /// For IM 1: PC is already set to 0x0038 and the return address has been pushed to the stack.
-        /// 
-        /// For IM 2: PC is already set to the address of the routine to execute and the return address has been pushed to the stack.
-        /// </summary>
-        event EventHandler MaskableInterruptServicingStart;
-
-        /// <summary>
-        /// Triggered when a non-maskable interrupt is about to be serviced.
-        /// PC is already set to 0x0066 and the return address has been pushed to the stack
-        /// when this event is invoked.
-        /// </summary>
-        event EventHandler NonMaskableInterruptServicingStart;
-
-        /// <summary>
-        /// Triggered before a RETI instruction is about to be executed,
-        /// right after the corresponding BeforeInstructionExecution event
-        /// </summary>
-        event EventHandler BeforeRetiInstructionExecution;
-
-        /// <summary>
-        /// Triggered after a RETI instruction has been executed,
-        /// right after the corresponding AfterInstructionExecution event
-        /// </summary>
-        event EventHandler AfterRetiInstructionExecution;
-
-        /// <summary>
-        /// Triggered before a RETN instruction is about to be executed,
-        /// right after the corresponding BeforeInstructionExecution event
-        /// </summary>
-        event EventHandler BeforeRetnInstructionExecution;
-
-        /// <summary>
-        /// Triggered after a RETN instruction has been executed,
-        /// right after the corresponding AfterInstructionExecution event
-        /// </summary>
-        event EventHandler AfterRetnInstructionExecution;
-
         #endregion
 
         #region Utils

--- a/Main/IZ80ProcessorInterruptEvents.cs
+++ b/Main/IZ80ProcessorInterruptEvents.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Konamiman.Z80dotNet
+{
+    /// <summary>
+    /// Complements <see cref="IZ80Processor"/> by adding events related to interrupts servicing. 
+    /// </summary>
+    public interface IZ80ProcessorInterruptEvents
+    {
+        /// <summary>
+        /// Triggered when a maskable interrupt is about to be serviced.
+        /// 
+        /// For IM 0: The opcode has been already fetched from the data bus and is about to be executed.
+        /// 
+        /// For IM 1: PC is already set to 0x0038 and the return address has been pushed to the stack.
+        /// 
+        /// For IM 2: PC is already set to the address of the routine to execute and the return address has been pushed to the stack.
+        /// </summary>
+        event EventHandler MaskableInterruptServicingStart;
+
+        /// <summary>
+        /// Triggered when a non-maskable interrupt is about to be serviced.
+        /// PC is already set to 0x0066 and the return address has been pushed to the stack
+        /// when this event is invoked.
+        /// </summary>
+        event EventHandler NonMaskableInterruptServicingStart;
+
+        /// <summary>
+        /// Triggered before a RETI instruction is about to be executed,
+        /// right after the corresponding BeforeInstructionExecution event
+        /// </summary>
+        event EventHandler BeforeRetiInstructionExecution;
+
+        /// <summary>
+        /// Triggered after a RETI instruction has been executed,
+        /// right after the corresponding AfterInstructionExecution event
+        /// </summary>
+        event EventHandler AfterRetiInstructionExecution;
+
+        /// <summary>
+        /// Triggered before a RETN instruction is about to be executed,
+        /// right after the corresponding BeforeInstructionExecution event
+        /// </summary>
+        event EventHandler BeforeRetnInstructionExecution;
+
+        /// <summary>
+        /// Triggered after a RETN instruction has been executed,
+        /// right after the corresponding AfterInstructionExecution event
+        /// </summary>
+        event EventHandler AfterRetnInstructionExecution;
+    }
+}

--- a/Main/Z80Processor.cs
+++ b/Main/Z80Processor.cs
@@ -8,7 +8,7 @@ namespace Konamiman.Z80dotNet
     /// <summary>
     /// The implementation of the <see cref="IZ80Processor"/> interface.
     /// </summary>
-    public class Z80Processor : IZ80Processor, IZ80ProcessorAgent
+    public class Z80Processor : IZ80Processor, IZ80ProcessorInterruptEvents, IZ80ProcessorAgent
     {
         private const int MemorySpaceSize = 65536;
         private const int PortSpaceSize = 256;


### PR DESCRIPTION
https://github.com/Konamiman/Z80dotNet/pull/4 introduced a new set of events, added to `IZ80Processor`, related to interrupts. This pull request moves these new events to a new interace, `IZ80ProcessorInterruptEvents`; the `Z80Processor` class implements now both `IZ80Processor` and the new interface. This is done to avoid breaking external code that depends on `IZ80Processor`.
